### PR TITLE
ステージ３のエレベーターに乗ってプレイヤーが動けなくなった後に、リスポーンのボタンを押すと、生きている状態のプレイヤーが残りプレイヤーの死…

### DIFF
--- a/Mobiuss/Mobiuss/Assets/NewTakesanPlayer/Script/PlayerDirector.cs
+++ b/Mobiuss/Mobiuss/Assets/NewTakesanPlayer/Script/PlayerDirector.cs
@@ -27,7 +27,9 @@ public class PlayerDirector : MonoBehaviour
     void Update()
     {
         if ((RespawnStack == false) && ((Input.GetKeyDown(KeyCode.R)) || (Input.GetKeyDown("joystick button 2")))){
-            StartRespawn();
+            if (Pass.PlayerCanMove == true){
+                StartRespawn();
+            }
         }
         SetPass();
     }


### PR DESCRIPTION
…体が出ず、２体目のプレイヤーが出現しステージ上にプレイヤーが二人存在できてしまうバグを修正。