### PR TITLE
ステージ２のレバーの使用ができる範囲内で死亡した際に、プレイヤーの座標を無視してレバーの操作ができてしまう問題を修正。爆弾を持った状態で死…

### DIFF
--- a/Mobiuss/Mobiuss/Assets/Scenes/Stage2.unity
+++ b/Mobiuss/Mobiuss/Assets/Scenes/Stage2.unity
@@ -10932,6 +10932,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: bom
       objectReference: {fileID: 0}
+    - target: {fileID: 6176694364796214941, guid: 561797c56009fe8459ff434eb37fce69,
+        type: 3}
+      propertyPath: m_Layer
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 8561151045147178757, guid: 561797c56009fe8459ff434eb37fce69,
         type: 3}
       propertyPath: m_Color.b

--- a/Mobiuss/Mobiuss/Assets/takestar1Script.cs
+++ b/Mobiuss/Mobiuss/Assets/takestar1Script.cs
@@ -35,7 +35,7 @@ public class takestar1Script : MonoBehaviour
         Debug.Log("s1"+pdiss);
         if (pdiss < 1.5)
         {
-            if ((Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1")) && (pih == false))
+            if ((Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1")) && (pih == false) && Pass.RespawnStack == false)
             {
                 NewSoundScriot.GetItem1 = true;
                 ch = true;

--- a/Mobiuss/Mobiuss/Assets/takestar2Script.cs
+++ b/Mobiuss/Mobiuss/Assets/takestar2Script.cs
@@ -37,7 +37,7 @@ public class takestar2Script : MonoBehaviour
         Debug.Log("s2" + pdiss);
         if (pdiss < 1.5)
         {
-            if ((Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1")) && (pih == false))
+            if ((Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1")) && (pih == false) && Pass.RespawnStack == false)
             {
                 NewSoundScriot.GetItem1 = true;
                 ch = true;

--- a/Mobiuss/Mobiuss/Assets/スクリプト/BomColor.cs
+++ b/Mobiuss/Mobiuss/Assets/スクリプト/BomColor.cs
@@ -38,5 +38,7 @@ public class BomColor : MonoBehaviour
         }
         
     }
-
+    public void ColorReset(){
+        this.GetComponent<SpriteRenderer>().color = new Color(1,1,1,1);
+    }
 }

--- a/Mobiuss/Mobiuss/Assets/スクリプト/bom.cs
+++ b/Mobiuss/Mobiuss/Assets/スクリプト/bom.cs
@@ -15,6 +15,7 @@ public class bom : MonoBehaviour
     bool PlayerRight;
     Rigidbody rb;
     Quaternion q;
+    bool canhold;
     //爆発エフェクト的なパーティクル
     public GameObject particleObject;
     [SerializeField] private GameObject BomYY;
@@ -29,7 +30,7 @@ public class bom : MonoBehaviour
         q = Quaternion.Euler(0, 0, 0);
         //player = GameObject.Find("New Sprite");
         BomYY.SetActive(false);
-
+        canhold = true;
     }
 
     private void Update()
@@ -46,7 +47,7 @@ public class bom : MonoBehaviour
             {
                 BomYY.SetActive(true);
             }
-            if (Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1"))
+            if ((Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1")) && itemposition == false && canhold == true && Pass.RespawnStack == false)
             {
                 NewSoundScriot.GetItem1 = true;
                 itemposition = true;
@@ -73,6 +74,7 @@ public class bom : MonoBehaviour
         {
             if (Input.GetKeyDown(KeyCode.I) || Input.GetKeyDown("joystick button 1"))
             {
+                canhold = false;
                 NewSoundScriot.UseItem1 = true;
                 rb.velocity = new Vector3(0,0,0);
                 transform.parent = null;
@@ -86,6 +88,12 @@ public class bom : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.R) || Input.GetKeyDown("joystick button 2")){
             itemposition = false;
             Pass.PlayerHold = false;
+        }
+        if (i == 1 && itemposition == true){
+            BomYY.SetActive(true);
+        }
+        if (i == 0 == itemposition == true){
+            BomYY.SetActive(false);
         }
     }
 
@@ -128,6 +136,7 @@ public class bom : MonoBehaviour
                 i=0;
                 GameObject iwa = Instantiate(CubePrefab);
                 iwa.transform.position = new Vector3(8.05f, -2.05f, 0);
+                FindObjectOfType<BomColor>().ColorReset();
             }
             Destroy(this.gameObject);
         }

--- a/Mobiuss/Mobiuss/Assets/スクリプト/reba.cs
+++ b/Mobiuss/Mobiuss/Assets/スクリプト/reba.cs
@@ -17,7 +17,7 @@ public class reba : MonoBehaviour
         RebaYY.SetActive(false);
 
     }
-    void OnTriggerStay(Collider other)
+    void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.tag == "player")
         {
@@ -56,6 +56,10 @@ public class reba : MonoBehaviour
                     myTransform.Rotate(0,  -180f,0, Space.World);
                 }
             }
+        }
+        if (Input.GetKeyDown(KeyCode.R) || Input.GetKeyDown("joystick button 2")){
+            n = 0;
+            RebaYY.SetActive(false);
         }
     }
        


### PR DESCRIPTION
…亡し、死亡のアニメーションが再生されている間にアイテムを持つ操作をすると、死亡しながらアイテムを持ち、スポーンすると爆弾を持った状態でスポーンしてしまい、爆弾を持っているのに持っていないときのアニメーションが再生されてしまう問題を修正。星にも同じ修正。爆弾を使用できる座標にプレイヤーがいる場合、Yボタンの視覚的なヒント表示させました。爆弾を使用し壁を破壊できなかったとき、再度生成される爆弾が赤い状態で生成されてしまう問題を修正。